### PR TITLE
chore: Add artifact attestation workflow

### DIFF
--- a/.github/workflows/artifact-attestations.yaml
+++ b/.github/workflows/artifact-attestations.yaml
@@ -1,0 +1,27 @@
+on:
+  pull_request:
+    paths:
+      - .github/workflows/artifact-attestations.yaml
+
+jobs:
+  attestation:
+    runs-on: ubuntu-latest
+
+    permissions:
+      id-token: write
+      attestations: write
+      contents: read
+
+    steps:
+      - run: date > date.txt
+
+      - name: Attest Build Provenance
+        uses: actions/attest-build-provenance@v1
+        with:
+          subject-path: "date.txt"
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: build-artifacts
+          path: date.txt


### PR DESCRIPTION
Introducing Artifact Attestations–now in public beta - The GitHub Blog
https://github.blog/2024-05-02-introducing-artifact-attestations-now-in-public-beta/

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a GitHub Actions workflow to run on pull requests, creating build attestations and uploading build artifacts. 



<!-- end of auto-generated comment: release notes by coderabbit.ai -->